### PR TITLE
Fix SHA1 out-of-bounds write

### DIFF
--- a/include/encrypt.hpp
+++ b/include/encrypt.hpp
@@ -11,36 +11,30 @@
 #include <wmmintrin.h>
 #endif
 
-
 namespace encryption {
 
 using encr_key_t = unsigned int;
 
 extern std::mt19937 encr_noise_generator;
 
-static unsigned int hashed_value_uint;
-static __m128i hashed_value_m128i;
-static __m256i hashed_value_m256i;
+alignas(__m256i) static unsigned char sha1_buf[32];
 
 inline unsigned int prng_uint(unsigned int input)
 {
-    SHA1(reinterpret_cast<unsigned char*>(&input), sizeof(unsigned int),
-	 reinterpret_cast<unsigned char*>(&hashed_value_uint));
-    return hashed_value_uint;
+    unsigned char* hash = SHA1(reinterpret_cast<unsigned char*>(&input), sizeof(unsigned int), sha1_buf);
+    return *reinterpret_cast<unsigned int*>(hash);
 }
 
 inline __m128i prng_m128(__m128i input)
 {
-    SHA1(reinterpret_cast<unsigned char*>(&input), sizeof(__m128i),
-	 reinterpret_cast<unsigned char*>(&hashed_value_m128i));
-    return hashed_value_m128i;
+    unsigned char* hash = SHA1(reinterpret_cast<unsigned char*>(&input), sizeof(__m128i), sha1_buf);
+    return *reinterpret_cast<__m128i*>(hash);
 }
 
 inline __m256i prng_m256(__m256i input)
 {
-    SHA1(reinterpret_cast<unsigned char*>(&input), sizeof(__m256i),
-	 reinterpret_cast<unsigned char*>(&hashed_value_m256i));
-    return hashed_value_m256i;
+    unsigned char* hash = SHA1(reinterpret_cast<unsigned char*>(&input), sizeof(__m256i), sha1_buf);
+    return *reinterpret_cast<__m256i*>(hash);
 }
 
 void encrypt_int_sum_naive(unsigned int *encr_sbuf, const unsigned int *sbuf, int count, int rank,


### PR DESCRIPTION
Hi, this fixes the SHA1-based PRNG implementations that would corrupt the libhear state when used.

According to the [docs](https://docs.openssl.org/3.0/man3/SHA256_Init/) for OpenSSL's `SHA1`:

```c
unsigned char *SHA1(const unsigned char *data, size_t count, unsigned char *md_buf);
```
> `SHA1()` computes the SHA-1 message digest of the `n` bytes at `d` and places it in `md` **(which must have space for `SHA_DIGEST_LENGTH` == 20 bytes of output)**.

Before this change, using the `prng_uint` function (default behavior without the AESNI environment variable) would make `SHA1` write past the allocated buffer for `md` (a single integer), corrupting the static state (usually seen as a segfault in either mpool or std::unordered_map).
